### PR TITLE
Added animation and moved order amount below image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ db_backups/
 reports/
 static/product_pics
 static/profile_pics
+postgREST.conf

--- a/src/Design.elm
+++ b/src/Design.elm
@@ -6,17 +6,11 @@ import Html.Events exposing (..)
 
 
 gridStyle =
-    [ style "display" "grid"
-    , style "grid-template-columns" "repeat(auto-fill, minmax(120px, 1fr))"
-    , style "grid-gap" "10px"
-    , style "grid-auto-flow" "dense"
-    , style "list-style" "none"
-    , style "margin" "1em auto"
-    , style "padding" "0"
-    , style "max-width" "800px"
+    [ class "grid"
     ]
 
 
+grid : List (Html msg) -> Html msg
 grid =
     div gridStyle
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -677,9 +677,9 @@ productView state buyState order =
             ]
         , b [] [ text order.product.name ]
         , br [] []
-        , span [ style "color" "blue" ] [ text (Round.round 2 order.product.price ++ "€") ]
+        , span [ class "productPrice" ] [ text (Round.round 2 order.product.price ++ "€") ]
         , br [] []
-        , text order.product.description
+        , span [ class "productDescription" ] [ text order.product.description ]
         ]
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -571,14 +571,16 @@ view model =
                     ]
                 , Design.grid
                     (List.map (productView state buyState) buyState.orders)
-                , h2 [] [ text "Kosten in den letzten 30 Tagen" ]
-                , p [] [ text <| Round.round 2 buyState.user.cost_last_30_days ++ "€" ]
-                , h2 [] [ text "Kosten in diesem Monat" ]
-                , p [] [ text <| Round.round 2 buyState.user.cost_this_month ++ "€" ]
-                , h2 [] [ text "Kosten im vergangenen Monat" ]
-                , p [] [ text <| Round.round 2 buyState.user.cost_last_month ++ "€" ]
-                , h2 [] [ text "Liter Bieräquivalent in den letzten 30 Tagen" ]
-                , p [] [ text <| Round.round 2 ((buyState.user.alc_ml_last_30_days / 0.05) / 1000) ]
+                , div [ class "stats" ]
+                    [ h2 [] [ text "Kosten in den letzten 30 Tagen" ]
+                    , p [] [ text <| Round.round 2 buyState.user.cost_last_30_days ++ "€" ]
+                    , h2 [] [ text "Kosten in diesem Monat" ]
+                    , p [] [ text <| Round.round 2 buyState.user.cost_this_month ++ "€" ]
+                    , h2 [] [ text "Kosten im vergangenen Monat" ]
+                    , p [] [ text <| Round.round 2 buyState.user.cost_last_month ++ "€" ]
+                    , h2 [] [ text "Liter Bieräquivalent in den letzten 30 Tagen" ]
+                    , p [] [ text <| Round.round 2 ((buyState.user.alc_ml_last_30_days / 0.05) / 1000) ]
+                    ]
                 ]
 
 
@@ -648,28 +650,34 @@ userView state user =
 productView : State -> BuyState -> NewOrder -> Html Msg
 productView state buyState order =
     let
-        productText =
+        countText =
             if order.amount == 0 then
-                order.product.name
+                ""
 
             else
-                order.product.name ++ " x" ++ String.fromInt order.amount
+                "x" ++ String.fromInt order.amount
     in
     div
         [ onClick (ClickedProduct state buyState order)
-        , style "margin" "10px"
-        , style "text-align" "center"
-        , style "touch-action" "manipulation"
+        , class "gridItem"
+        , class
+            (if order.amount == 0 then
+                "notSelected"
+
+             else
+                "selected"
+            )
         ]
-        [ img
-            [ src order.product.image
-            , style "height" "200px"
+        [ div [ class "imgContainer" ]
+            [ img
+                [ src order.product.image
+                ]
+                []
+            , p [] [ text countText ]
             ]
-            []
+        , b [] [ text order.product.name ]
         , br [] []
-        , b [] [ text productText ]
-        , br [] []
-        , text (Round.round 2 order.product.price ++ "€")
+        , span [ style "color" "blue" ] [ text (Round.round 2 order.product.price ++ "€") ]
         , br [] []
         , text order.product.description
         ]

--- a/static/index.html
+++ b/static/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Strichliste 2.0</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style.css?v=1.1" />
     <script src="main.js"></script>
   </head>
 

--- a/static/main.js
+++ b/static/main.js
@@ -7893,7 +7893,7 @@ var $author$project$Main$productView = F3(
 					$elm$html$Html$span,
 					_List_fromArray(
 						[
-							A2($elm$html$Html$Attributes$style, 'color', 'blue')
+							$elm$html$Html$Attributes$class('productPrice')
 						]),
 					_List_fromArray(
 						[
@@ -7901,7 +7901,16 @@ var $author$project$Main$productView = F3(
 							A2($myrho$elm_round$Round$round, 2, order.aO._) + '€')
 						])),
 					A2($elm$html$Html$br, _List_Nil, _List_Nil),
-					$elm$html$Html$text(order.aO.W)
+					A2(
+					$elm$html$Html$span,
+					_List_fromArray(
+						[
+							$elm$html$Html$Attributes$class('productDescription')
+						]),
+					_List_fromArray(
+						[
+							$elm$html$Html$text(order.aO.W)
+						]))
 				]));
 	});
 var $author$project$Design$red = A2($author$project$Design$ButtonColor, '#CF1E36', '#FFFFFF');

--- a/static/main.js
+++ b/static/main.js
@@ -7527,6 +7527,14 @@ var $author$project$Design$button = F3(
 				]));
 	});
 var $elm$html$Html$button = _VirtualDom_node('button');
+var $elm$html$Html$Attributes$stringProperty = F2(
+	function (key, string) {
+		return A2(
+			_VirtualDom_property,
+			key,
+			$elm$json$Json$Encode$string(string));
+	});
+var $elm$html$Html$Attributes$class = $elm$html$Html$Attributes$stringProperty('className');
 var $author$project$Design$ButtonColor = F2(
 	function (a, b) {
 		return {$: 0, a: a, b: b};
@@ -7534,14 +7542,7 @@ var $author$project$Design$ButtonColor = F2(
 var $author$project$Design$green = A2($author$project$Design$ButtonColor, '#1B6525', '#FFFFFF');
 var $author$project$Design$gridStyle = _List_fromArray(
 	[
-		A2($elm$html$Html$Attributes$style, 'display', 'grid'),
-		A2($elm$html$Html$Attributes$style, 'grid-template-columns', 'repeat(auto-fill, minmax(120px, 1fr))'),
-		A2($elm$html$Html$Attributes$style, 'grid-gap', '10px'),
-		A2($elm$html$Html$Attributes$style, 'grid-auto-flow', 'dense'),
-		A2($elm$html$Html$Attributes$style, 'list-style', 'none'),
-		A2($elm$html$Html$Attributes$style, 'margin', '1em auto'),
-		A2($elm$html$Html$Attributes$style, 'padding', '0'),
-		A2($elm$html$Html$Attributes$style, 'max-width', '800px')
+		$elm$html$Html$Attributes$class('grid')
 	]);
 var $author$project$Design$grid = $elm$html$Html$div($author$project$Design$gridStyle);
 var $elm$html$Html$h1 = _VirtualDom_node('h1');
@@ -7835,13 +7836,7 @@ var $myrho$elm_round$Round$round = $myrho$elm_round$Round$roundFun(
 				}
 			}
 		}));
-var $elm$html$Html$Attributes$stringProperty = F2(
-	function (key, string) {
-		return A2(
-			_VirtualDom_property,
-			key,
-			$elm$json$Json$Encode$string(string));
-	});
+var $elm$html$Html$span = _VirtualDom_node('span');
 var $elm$html$Html$Attributes$src = function (url) {
 	return A2(
 		$elm$html$Html$Attributes$stringProperty,
@@ -7850,38 +7845,61 @@ var $elm$html$Html$Attributes$src = function (url) {
 };
 var $author$project$Main$productView = F3(
 	function (state, buyState, order) {
-		var productText = (!order.ai) ? order.aO.B : (order.aO.B + (' x' + $elm$core$String$fromInt(order.ai)));
+		var countText = (!order.ai) ? '' : ('x' + $elm$core$String$fromInt(order.ai));
 		return A2(
 			$elm$html$Html$div,
 			_List_fromArray(
 				[
 					$elm$html$Html$Events$onClick(
 					A3($author$project$Main$ClickedProduct, state, buyState, order)),
-					A2($elm$html$Html$Attributes$style, 'margin', '10px'),
-					A2($elm$html$Html$Attributes$style, 'text-align', 'center'),
-					A2($elm$html$Html$Attributes$style, 'touch-action', 'manipulation')
+					$elm$html$Html$Attributes$class('gridItem'),
+					$elm$html$Html$Attributes$class(
+					(!order.ai) ? 'notSelected' : 'selected')
 				]),
 			_List_fromArray(
 				[
 					A2(
-					$elm$html$Html$img,
+					$elm$html$Html$div,
 					_List_fromArray(
 						[
-							$elm$html$Html$Attributes$src(order.aO.X),
-							A2($elm$html$Html$Attributes$style, 'height', '200px')
+							$elm$html$Html$Attributes$class('imgContainer')
 						]),
-					_List_Nil),
-					A2($elm$html$Html$br, _List_Nil, _List_Nil),
+					_List_fromArray(
+						[
+							A2(
+							$elm$html$Html$img,
+							_List_fromArray(
+								[
+									$elm$html$Html$Attributes$src(order.aO.X)
+								]),
+							_List_Nil),
+							A2(
+							$elm$html$Html$p,
+							_List_Nil,
+							_List_fromArray(
+								[
+									$elm$html$Html$text(countText)
+								]))
+						])),
 					A2(
 					$elm$html$Html$b,
 					_List_Nil,
 					_List_fromArray(
 						[
-							$elm$html$Html$text(productText)
+							$elm$html$Html$text(order.aO.B)
 						])),
 					A2($elm$html$Html$br, _List_Nil, _List_Nil),
-					$elm$html$Html$text(
-					A2($myrho$elm_round$Round$round, 2, order.aO._) + '€'),
+					A2(
+					$elm$html$Html$span,
+					_List_fromArray(
+						[
+							A2($elm$html$Html$Attributes$style, 'color', 'blue')
+						]),
+					_List_fromArray(
+						[
+							$elm$html$Html$text(
+							A2($myrho$elm_round$Round$round, 2, order.aO._) + '€')
+						])),
 					A2($elm$html$Html$br, _List_Nil, _List_Nil),
 					$elm$html$Html$text(order.aO.W)
 				]));
@@ -8181,64 +8199,73 @@ var $author$project$Main$view = function (model) {
 							A2($author$project$Main$productView, state, buyState),
 							buyState.f)),
 						A2(
-						$elm$html$Html$h2,
-						_List_Nil,
+						$elm$html$Html$div,
 						_List_fromArray(
 							[
-								$elm$html$Html$text('Kosten in den letzten 30 Tagen')
-							])),
-						A2(
-						$elm$html$Html$p,
-						_List_Nil,
+								$elm$html$Html$Attributes$class('stats')
+							]),
 						_List_fromArray(
 							[
-								$elm$html$Html$text(
-								A2($myrho$elm_round$Round$round, 2, buyState.a2.bd) + '€')
-							])),
-						A2(
-						$elm$html$Html$h2,
-						_List_Nil,
-						_List_fromArray(
-							[
-								$elm$html$Html$text('Kosten in diesem Monat')
-							])),
-						A2(
-						$elm$html$Html$p,
-						_List_Nil,
-						_List_fromArray(
-							[
-								$elm$html$Html$text(
-								A2($myrho$elm_round$Round$round, 2, buyState.a2.bf) + '€')
-							])),
-						A2(
-						$elm$html$Html$h2,
-						_List_Nil,
-						_List_fromArray(
-							[
-								$elm$html$Html$text('Kosten im vergangenen Monat')
-							])),
-						A2(
-						$elm$html$Html$p,
-						_List_Nil,
-						_List_fromArray(
-							[
-								$elm$html$Html$text(
-								A2($myrho$elm_round$Round$round, 2, buyState.a2.be) + '€')
-							])),
-						A2(
-						$elm$html$Html$h2,
-						_List_Nil,
-						_List_fromArray(
-							[
-								$elm$html$Html$text('Liter Bieräquivalent in den letzten 30 Tagen')
-							])),
-						A2(
-						$elm$html$Html$p,
-						_List_Nil,
-						_List_fromArray(
-							[
-								$elm$html$Html$text(
-								A2($myrho$elm_round$Round$round, 2, (buyState.a2.a8 / 0.05) / 1000))
+								A2(
+								$elm$html$Html$h2,
+								_List_Nil,
+								_List_fromArray(
+									[
+										$elm$html$Html$text('Kosten in den letzten 30 Tagen')
+									])),
+								A2(
+								$elm$html$Html$p,
+								_List_Nil,
+								_List_fromArray(
+									[
+										$elm$html$Html$text(
+										A2($myrho$elm_round$Round$round, 2, buyState.a2.bd) + '€')
+									])),
+								A2(
+								$elm$html$Html$h2,
+								_List_Nil,
+								_List_fromArray(
+									[
+										$elm$html$Html$text('Kosten in diesem Monat')
+									])),
+								A2(
+								$elm$html$Html$p,
+								_List_Nil,
+								_List_fromArray(
+									[
+										$elm$html$Html$text(
+										A2($myrho$elm_round$Round$round, 2, buyState.a2.bf) + '€')
+									])),
+								A2(
+								$elm$html$Html$h2,
+								_List_Nil,
+								_List_fromArray(
+									[
+										$elm$html$Html$text('Kosten im vergangenen Monat')
+									])),
+								A2(
+								$elm$html$Html$p,
+								_List_Nil,
+								_List_fromArray(
+									[
+										$elm$html$Html$text(
+										A2($myrho$elm_round$Round$round, 2, buyState.a2.be) + '€')
+									])),
+								A2(
+								$elm$html$Html$h2,
+								_List_Nil,
+								_List_fromArray(
+									[
+										$elm$html$Html$text('Liter Bieräquivalent in den letzten 30 Tagen')
+									])),
+								A2(
+								$elm$html$Html$p,
+								_List_Nil,
+								_List_fromArray(
+									[
+										$elm$html$Html$text(
+										A2($myrho$elm_round$Round$round, 2, (buyState.a2.a8 / 0.05) / 1000))
+									]))
 							]))
 					]));
 	}

--- a/static/style.css
+++ b/static/style.css
@@ -68,3 +68,11 @@ html {
 .stats p {
   margin-top: 0.5em;
 }
+
+.productDescription {
+  color: #777;
+}
+
+.productPrice {
+  font-weight: 500;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,70 @@
+html {
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  grid-gap: 10px;
+  grid-auto-flow: dense;
+  list-style: none;
+  margin: 1em auto;
+  padding: 0;
+}
+
+.gridItem {
+  margin: 10px;
+  text-align: center;
+  touch-action: manipulation;
+}
+
+.imgContainer {
+  position: relative;
+  height: 200px;
+  margin-bottom: 15px;
+  transition: margin-bottom 100ms, height 100ms;
+}
+
+.imgContainer p {
+  display: block;
+  position: absolute;
+  bottom: 3px;
+  left: 0;
+  right: 0;
+
+  font-size: 32px;
+  font-weight: bold;
+
+  color: #000;
+  text-align: center;
+  margin: 0;
+  user-select: none;
+}
+
+.imgContainer img {
+  position: absolute;
+  top: 0;
+  left: -9999px;
+  right: -9999px;
+  margin: auto;
+
+  height: 200px;
+  transition: height 100ms;
+}
+
+.selected .imgContainer {
+  margin-bottom: 0;
+  height: 215px;
+}
+
+.selected .imgContainer img {
+  height: 170px;
+}
+
+.stats h2 {
+  margin-bottom: 0;
+}
+
+.stats p {
+  margin-top: 0.5em;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -70,7 +70,7 @@ html {
 }
 
 .productDescription {
-  color: #777;
+  color: #555;
 }
 
 .productPrice {


### PR DESCRIPTION
This pull request improves the readability of the product ordering ui by moving the order amount from the product name to a text element below the product image. Furthermore the product image shrinks when a product is selected.

![image](https://user-images.githubusercontent.com/28311288/207580443-3108b23b-3cf5-4464-98e4-0a8392bc991f.png)
